### PR TITLE
Allow Content-Type and Accept header used in the webapp

### DIFF
--- a/src/sab.com/gae/admin-module/admin.go
+++ b/src/sab.com/gae/admin-module/admin.go
@@ -10,6 +10,7 @@ func withContext(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		GetContextStore().SetContext(appengine.NewContext(r))
 		w.Header().Add("Access-Control-Allow-Origin", "*")
+		w.Header().Add("Access-Control-Allow-Headers", "Content-Type, Accept")
 		f(w, r)
 	}
 }


### PR DESCRIPTION
- This allow Content-Type and Accept headers used by the webapp when requesting graphql resources.